### PR TITLE
Split maps.jinja

### DIFF
--- a/hostapd/defaults.yaml
+++ b/hostapd/defaults.yaml
@@ -1,0 +1,11 @@
+hostapd:
+  pkgs: []
+  realtek_pkgs: []
+  atheros_pkgs: []
+  mode: '600'
+  user: root
+  group: root
+  conf_dir: /etc/hostapd
+  conf_file: hostapd.conf
+  service: hostapd
+  defaults_file: /etc/default/hostapd

--- a/hostapd/init.sls
+++ b/hostapd/init.sls
@@ -22,8 +22,10 @@ hostapd_pkgs:
 hostapd_activate:
   file.replace:
     - name: {{ map.defaults_file }}
-    - pattern: "^DAEMON_CONF=.*$"
+    - pattern: "^(|#)DAEMON_CONF=.*$"
     - repl: "DAEMON_CONF='{% for card in salt['pillar.get']('hostapd:cardlist', {}).keys() %}{{ card2conf(card, map) }} {% endfor %}'"
+    - watch_in:
+      - service: hostapd_service
 {%- endif %}      
 
 # Ensure hostapd service is running and autostart is enabled

--- a/hostapd/map.jinja
+++ b/hostapd/map.jinja
@@ -1,34 +1,17 @@
-{% set map = salt['grains.filter_by']({
-    'Debian': {
-        'pkgs': ['hostapd', 'iw', 'wireless-tools'],
-        'realtek_pkgs': ['firmware-realtek'],
-        'atheros_pkgs': ['firmware-atheros'],
-        'service': 'hostapd',
-        'conf_dir': '/etc/hostapd',
-        'conf_file': 'hostapd.conf',
-        'user': 'root',
-        'group': 'root',
-        'mode': '600',
-        'defaults_file': '/etc/default/hostapd',
-    },
-    'Ubuntu': {
-        'pkgs': ['hostapd', 'iw', 'wireless-tools'],
-        'realtek_pkgs': [],
-        'atheros_pkgs': [],
-        'service': 'hostapd',
-        'conf_dir': '/etc/hostapd',
-        'conf_file': 'hostapd.conf',
-        'user': 'root',
-        'group': 'root',
-        'mode': '600',
-        'defaults_file': '/etc/default/hostapd',
-    },
-    'FreeBSD': {
-        'service': 'hostapd',
-        'conf_dir': '/etc',
-        'conf_file': 'hostapd.conf',
-        'user': 'root',
-        'group': 'wheel',
-        'mode': '600',
-    },
-}, grain='os', merge=salt['pillar.get']('hostapd:lookup')) %}
+{% import_yaml "hostapd/defaults.yaml" as defaults %}
+{% import_yaml "hostapd/osfamilymap.yaml" as osfamilymap %}
+{% import_yaml "hostapd/osmap.yaml" as osmap %}
+
+{%- set map = salt['grains.filter_by'](
+    defaults,
+    merge=salt['grains.filter_by'](
+        osfamilymap,
+        grain='os_family',
+        merge=salt['grains.filter_by'](
+            osmap,
+            grain='os',
+            merge=salt['pillar.get']('hostapd:lookup', {}),
+        ),
+    ),
+    base='hostapd')
+%}

--- a/hostapd/osfamilymap.yaml
+++ b/hostapd/osfamilymap.yaml
@@ -1,0 +1,9 @@
+Debian:
+  pkgs: ['hostapd', 'iw', 'wireless-tools']
+  realtek_pkgs: ['firmware-realtek']
+  atheros_pkgs: ['firmware-atheros']
+Ubuntu:
+  pkgs: ['hostapd', 'iw', 'wireless-tools']
+FreeBSD:
+  conf_dir: /etc
+  group: wheel

--- a/hostapd/osmap.yaml
+++ b/hostapd/osmap.yaml
@@ -1,0 +1,1 @@
+Raspbian: {}


### PR DESCRIPTION
- into defaults, osfamilymap & osmap.
- Added Raspbian support.

Tested on `Raspbian GNU/Linux 9.6 (stretch)`.