### PR TITLE
Fix trailing blank

### DIFF
--- a/hostapd/files/hostapd.conf.jinja
+++ b/hostapd/files/hostapd.conf.jinja
@@ -1,6 +1,5 @@
 ctrl_interface=/var/run/hostapd
 ctrl_interface_group=0
-{%- set card_data = salt['pillar.get']("hostapd:cardlist:{}".format(card), {}) %}
 interface={{ card }}
 {%- if card_data.driver is defined %}
 driver={{ card_data.driver }}

--- a/hostapd/files/hostapd.conf.jinja
+++ b/hostapd/files/hostapd.conf.jinja
@@ -26,7 +26,7 @@ wmm_enabled={{ card_data.get('wmm_enabled') }}
 {%- endif %}
 {#- don't break compatibility with old config format #}
 {%- set ap_list_orig = card_data.get('ap_list', {}) %}
-{%- set ap_list = ap_list_orig.iteritems() if ap_list_orig is mapping else ap_list_orig %}
+{%- set ap_list = ap_list_orig.items() if ap_list_orig is mapping else ap_list_orig %}
 {%- for ap in ap_list %}
 {%- set ap_name = ap['ssid'] if ap is mapping else ap[0] %}
 {%- set ap_data = ap if ap is mapping else ap[1] %}

--- a/hostapd/init.sls
+++ b/hostapd/init.sls
@@ -2,9 +2,14 @@
 
 {% from "hostapd/map.jinja" import map with context %}
 
-{% macro card2conf(card, map) -%}
-{{ map.conf_dir }}/{{ map.conf_file|replace('.conf', "_{}.conf".format(card)) }}
-{%- endmacro %}
+{#- Create card to config mapping #}
+{%- set daemon_conf = {} %}
+{%- set card_conf = {} %}
+{%- for card, data in salt['pillar.get']('hostapd:cardlist', {})|dictsort %}
+{%-   set cfg_file = '%s/%s_%s.conf'|format(map.conf_dir, map.conf_file|replace('.conf', ''), card) %}
+{%-   do daemon_conf.update({card: cfg_file}) %}
+{%-   do card_conf.update({card: data}) %}
+{%- endfor %}
 
 # Install packages
 {%- if map.pkgs is defined %}
@@ -19,16 +24,11 @@ hostapd_pkgs:
 {%- endif %}      
 
 {%- if map.defaults_file is defined %}
-{%-   set daemon_conf = [] %}
-{%-   for card in salt['pillar.get']('hostapd:cardlist', {}) %}
-{%-     set entry %}{{ card2conf(card, map) }}{% endset %}
-{%-     do daemon_conf.append(entry) %}
-{%-   endfor %}
 hostapd_activate:
   file.replace:
     - name: {{ map.defaults_file }}
     - pattern: "^(|#)DAEMON_CONF=.*$"
-    - repl: "DAEMON_CONF='{{ daemon_conf|join(" ") }}'"
+    - repl: "DAEMON_CONF='{{ daemon_conf.values()|join(" ") }}'"
     - watch_in:
       - service: hostapd_service
 {%- endif %}      
@@ -39,14 +39,15 @@ hostapd_service:
     - name: {{ map.service }}
     - enable: True
 
-{% for card in salt['pillar.get']('hostapd:cardlist', {}).keys() %}
+{% for card, conf in daemon_conf|dictsort %}
 hostapd_config_{{ card }}:
   file.managed:
-    - name: {{ card2conf(card, map) }}
+    - name: {{ conf }}
     - source: salt://hostapd/files/hostapd.conf.jinja
     - template: jinja  
     - context:
       card: {{ card }}
+      card_data: {{ card_conf[card] | json }}
     - user: {{ map.user }}
     - group: {{ map.group }}
     - mode: {{ map.mode }}  

--- a/hostapd/init.sls
+++ b/hostapd/init.sls
@@ -27,8 +27,8 @@ hostapd_pkgs:
 hostapd_activate:
   file.replace:
     - name: {{ map.defaults_file }}
-    - pattern: "^(|#)DAEMON_CONF=.*$"
-    - repl: "DAEMON_CONF='{{ daemon_conf.values()|join(" ") }}'"
+    - pattern: ^(|#)DAEMON_CONF=.*$
+    - repl: DAEMON_CONF='{{ daemon_conf.values()|join(" ") }}'
     - watch_in:
       - service: hostapd_service
 {%- endif %}      

--- a/hostapd/init.sls
+++ b/hostapd/init.sls
@@ -19,11 +19,16 @@ hostapd_pkgs:
 {%- endif %}      
 
 {%- if map.defaults_file is defined %}
+{%-   set daemon_conf = [] %}
+{%-   for card in salt['pillar.get']('hostapd:cardlist', {}) %}
+{%-     set entry %}{{ card2conf(card, map) }}{% endset %}
+{%-     do daemon_conf.append(entry) %}
+{%-   endfor %}
 hostapd_activate:
   file.replace:
     - name: {{ map.defaults_file }}
     - pattern: "^(|#)DAEMON_CONF=.*$"
-    - repl: "DAEMON_CONF='{% for card in salt['pillar.get']('hostapd:cardlist', {}).keys() %}{{ card2conf(card, map) }} {% endfor %}'"
+    - repl: "DAEMON_CONF='{{ daemon_conf|join(" ") }}'"
     - watch_in:
       - service: hostapd_service
 {%- endif %}      


### PR DESCRIPTION
A (formerly working) config including a trailing blank in `DAEMON_CONF` ceased functioning.
I removed the blank. Service started without problems.

Tested on Raspbian 9.