### PR TITLE
Support multiple WiFi adapters

### DIFF
--- a/hostapd/files/defaults.jinja
+++ b/hostapd/files/defaults.jinja
@@ -1,0 +1,23 @@
+# Defaults for hostapd initscript
+#
+# See /usr/share/doc/hostapd/README.Debian for information about alternative
+# methods of managing hostapd.
+#
+# Uncomment and set DAEMON_CONF to the absolute path of a hostapd configuration
+# file and hostapd will be started during system boot. An example configuration
+# file can be found at /usr/share/doc/hostapd/examples/hostapd.conf.gz
+#
+#DAEMON_CONF='/etc/hostapd/hostapd.conf'
+{%- for card, file in daemon_conf.items() %}
+DAEMON_CONF_{{ card }}='{{ file }}'
+{%- endfor %}
+
+# Additional daemon options to be appended to hostapd command:-
+#       -d   show more debug messages (-dd for even more)
+#       -K   include key data in debug messages
+#       -t   include timestamps in some debug messages
+#
+# Note that -B (daemon mode) and -P (pidfile) options are automatically
+# configured by the init.d script and must not be added to DAEMON_OPTS.
+#
+#DAEMON_OPTS=""

--- a/pillar.example
+++ b/pillar.example
@@ -50,3 +50,19 @@ hostapd:
         - ssid: myssid3
           bss: wlan2
           wpa_passphrase: someotherpassword3
+    wlan1:
+      bridge: br1
+      hw_mode: g                 # g simply means 2.4GHz
+      channel: 10               # the channel to use
+      ieee80211d: 1             # limit the frequencies used to those allowed in the country
+      country_code: DE          # the country code
+      ieee80211n: 1             # 802.11n support
+      wmm_enabled: 1            # QoS support
+      ap_list:
+        myssid2:                # the name of the AP
+          auth_algs: 1          # 1=wpa, 2=wep, 3=both
+          wpa: 2                # WPA2 only
+          wpa_key_mgmt: WPA-PSK 
+          rsn_pairwise: CCMP
+          wpa_passphrase: mysupersecretkey
+      


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

On Raspberry Pi (at least from my experiments) a single hostapd process managing all WiFi adapters was required. Therefore the systemd unit needs to provide multiple configuration files. This only works by introducing new environment variables into `/etc/default/hostapd`.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
% salt --state-output=changes 'host' state.apply hostapd 
rpi-ap.mgmt.tty1.eu:
  Name: hostapd_pkgs - Function: pkg.installed - Result: Clean Started: - 08:56:20.584992 Duration: 3584.653 ms
  Name: /etc/default/hostapd - Function: file.managed - Result: Clean Started: - 08:56:24.197453 Duration: 230.94 ms
  Name: /etc/systemd/system/hostapd.service.d/multi-interface.conf - Function: file.managed - Result: Clean Started: - 08:56:24.429508 Duration: 8.25 ms
  Name: systemctl daemon-reload - Function: cmd.run - Result: Clean Started: - 08:56:24.449592 Duration: 0.13 ms
  Name: /etc/hostapd/wlan1.conf - Function: file.managed - Result: Clean Started: - 08:56:24.467669 Duration: 342.293 ms
  Name: /etc/hostapd/wlan2.conf - Function: file.managed - Result: Clean Started: - 08:56:24.811143 Duration: 333.542 ms
  Name: hostapd - Function: service.running - Result: Clean Started: - 08:56:25.148379 Duration: 315.267 ms

Summary for host
------------
Succeeded: 7
Failed:    0
------------
Total states run:     7
Total run time:   4.815 s
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


